### PR TITLE
Update links for Norwegian artists and practitioners

### DIFF
--- a/book/listening.ipynb
+++ b/book/listening.ipynb
@@ -373,11 +373,11 @@
     "\n",
     "Norway has a vibrant community of artists and researchers working with soundscapes, listening practices, acoustic ecology, and electroacoustic composition, including: \n",
     "\n",
-    "- **[Britt Pernille Frøholm](https://www.brittpernillefroholm.no/)** (1974–): Composer and performer exploring acoustic ecology and soundscape composition in Norwegian landscapes.\n",
-    "- **[Espen Sommer Eide](https://www.sommer-eide.net/)** (1972–): Artist and musician working with field recordings, sound installations, and listening walks.\n",
+    "- **[Britt Pernille Frøholm](https://nn.wikipedia.org/wiki/Britt_Pernille_Fr%C3%B8holm)** (1974–): Composer and performer exploring acoustic ecology and soundscape composition in Norwegian landscapes.\n",
+    "- **[Espen Sommer Eide](https://www.alog.net/)** (1972–): Artist and musician working with field recordings, sound installations, and listening walks.\n",
     "- **[Jana Winderen](https://www.janawinderen.com/)** (1965–): Sound artist whose field recordings and installations focus on underwater and natural sound environments.\n",
     "- **[Maja S. K. Ratkje](https://ratkje.no/)** (1973–): Composer and performer integrating environmental sounds and experimental listening in her works.\n",
-    "- **[Natasha Barrett](https://www.natashabarrett.org/)** (1972–): Composer and sound artist specialising in spatial audio, immersive sound installations, and electroacoustic composition.\n",
+    "- **[Natasha Barrett](https://www.natashabarrett.net/)** (1972–): Composer and sound artist specialising in spatial audio, immersive sound installations, and electroacoustic composition.\n",
     "\n",
     "These practitioners have contributed to both artistic and academic developments in the field, often collaborating across disciplines to deepen our understanding of sound and listening in Norwegian contexts.\n"
    ]


### PR DESCRIPTION
Chapter 2 lists some Norwegian artists and practitioners, but many of the links are not working or changed:

- Frøholm's webiste seems not continued, so I changed the link to her wikipedia page.
- Eide's new website is at https://www.alog.net/
- Barrett has a new website at https://www.natashabarrett.net/

The links for Winderen and Ratkje works fine.

Best,
Arthur